### PR TITLE
docs: 修复 README 徽章图片

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [中文](README.md) | [English](README_EN.md)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![MCP](https://img.shields.io/badge/MCP-Streamable_HTTP-168AAD)
-![Tools](https://img.shields.io/badge/tools-172-blue)
+![MCP](https://img.shields.io/badge/MCP-Streamable_HTTP-168AAD.svg)
+![Tools](https://img.shields.io/badge/tools-172-blue.svg)
 
 FTShare MCP 是面向 AI Agent 的金融数据 MCP 服务，让 Claude Code、Codex、WorkBuddy、OpenClaw、Hermes 等支持 MCP 的客户端，可以通过自然语言调用 FTShare 的行情、财务、宏观、基金、期货、债券、美股和港股数据。
 


### PR DESCRIPTION
## 问题

README 新增的 MCP 和 Tools 徽章地址缺少 `.svg` 后缀，GitHub 页面显示为破图。

## 修复

- 为 MCP 徽章补充 `.svg`
- 为 Tools 徽章补充 `.svg`
- `git diff --check` 通过
